### PR TITLE
Add User Flags

### DIFF
--- a/Controllers/AppController.cs
+++ b/Controllers/AppController.cs
@@ -40,11 +40,10 @@ namespace GaryPortalAPI.Controllers
             return Ok(await _appService.GetCommandmentsAsync(ct));
         }
 
-        [AllowAnonymous]
-        [HttpGet("TestDocker")]
-        public async Task<IActionResult> TestDocker()
+        [HttpGet("Flags")]
+        public async Task<IActionResult> GetAllFlags(CancellationToken ct = default)
         {
-            return Ok(10);
+            return Ok(await _appService.GetAllFlagsAsync(ct));
         }
     }
 }

--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -97,8 +97,6 @@ namespace GaryPortalAPI.Controllers
             return Ok(await _userRepository.UpdateUserDetailsAsync(uuid, details, ct));
         }
 
-
-
         [HttpPost("UpdateProfilePictureForUser/{uuid}")]
         public async Task<IActionResult> UpdateProfilePictureForUser(string uuid, CancellationToken ct = default)
         {
@@ -151,6 +149,18 @@ namespace GaryPortalAPI.Controllers
                 await _userRepository.PostNotification(token, Notification.CreateNotification(new APSAlert { body = content }));
             }
             return Ok();
+        }
+
+        [HttpPut("SetUserFlag/{userUUID}")]
+        public async Task<IActionResult> SetUserFlag(string userUUID, string flagName, bool enabled = true, CancellationToken ct = default)
+        {
+            if (string.IsNullOrEmpty(userUUID) || string.IsNullOrEmpty(flagName))
+            {
+                return BadRequest();
+            }
+
+            UserFlag userFlag = await _userRepository.SetUserFlag(userUUID, flagName, enabled, ct);
+            return userFlag != null ? Ok(userFlag) : BadRequest("Invalid userUUID or flag name");
         }
     }
 }

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -12,6 +12,7 @@ public class AppDbContext : DbContext
     public DbSet<User> Users { get; set; }
     public DbSet<Rank> Ranks { get; set; }
     public DbSet<Team> Teams { get; set; }
+    public DbSet<Flag> Flags { get; set; }
 
     public DbSet<UserAuthentication> UserAuthentications { get; set; }
     public DbSet<UserRefreshToken> UserRefreshTokens { get; set; }
@@ -20,6 +21,7 @@ public class AppDbContext : DbContext
     public DbSet<UserTeam> UserTeams { get; set; }
     public DbSet<UserBlock> UserBlocks { get; set; }
     public DbSet<UserAPNS> UserAPNS { get; set; }
+    public DbSet<UserFlag> UserFlags { get; set; }
 
     public DbSet<UserAuthenticationConfirmation> UserAuthConfirmations { get; set; }
     public DbSet<UserPassResetToken> UserPassResetTokens { get; set; }
@@ -122,6 +124,13 @@ public class AppDbContext : DbContext
                 .HasForeignKey(apns => apns.UserUUID)
                 .OnDelete(DeleteBehavior.Cascade)
                 .IsRequired();
+
+            entity
+                .HasMany(u => u.UserFlags)
+                .WithOne()
+                .HasForeignKey(uf => uf.UserUUID)
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
         });
 
         modelBuilder.Entity<UserAuthentication>(entity =>
@@ -202,6 +211,24 @@ public class AppDbContext : DbContext
                 .OnDelete(DeleteBehavior.Cascade)
                 .IsRequired();
             entity.Ignore(ub => ub.BlockedUserDTO);
+        });
+
+        modelBuilder.Entity<Flag>(entity =>
+        {
+            entity.Property(f => f.FlagId)
+                .ValueGeneratedOnAdd();
+            entity.HasKey(f => f.FlagId);
+        });
+
+        modelBuilder.Entity<UserFlag>(entity =>
+        {
+            entity.HasKey(uf => new { uf.FlagId, uf.UserUUID });
+            entity
+                .HasOne(uf => uf.Flag)
+                .WithMany()
+                .HasForeignKey(uf => uf.FlagId)
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
         });
 
         #endregion User

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -131,6 +131,10 @@ public class AppDbContext : DbContext
                 .HasForeignKey(uf => uf.UserUUID)
                 .OnDelete(DeleteBehavior.Cascade)
                 .IsRequired();
+
+            entity.Ignore(u => u.UserIsStaff);
+            entity.Ignore(u => u.UserIsAdmin);
+            entity.Ignore(u => u.IsQueued);
         });
 
         modelBuilder.Entity<UserAuthentication>(entity =>

--- a/Migrations/20210904162850_UserFlags.Designer.cs
+++ b/Migrations/20210904162850_UserFlags.Designer.cs
@@ -2,14 +2,16 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GaryPortalAPI.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210904162850_UserFlags")]
+    partial class UserFlags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20210904162850_UserFlags.cs
+++ b/Migrations/20210904162850_UserFlags.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GaryPortalAPI.Migrations
+{
+    public partial class UserFlags : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsQueued",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "NotificationsMuted",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "UserIsAdmin",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "UserIsStaff",
+                table: "Users");
+
+            migrationBuilder.CreateTable(
+                name: "Flags",
+                columns: table => new
+                {
+                    FlagId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    FlagName = table.Column<string>(type: "longtext", nullable: true),
+                    FlagAccessLevel = table.Column<int>(type: "int", nullable: false),
+                    FlagIsDeleted = table.Column<bool>(type: "tinyint(1)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Flags", x => x.FlagId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserFlags",
+                columns: table => new
+                {
+                    UserUUID = table.Column<string>(type: "varchar(255)", nullable: false),
+                    FlagId = table.Column<int>(type: "int", nullable: false),
+                    FlagEnabled = table.Column<bool>(type: "tinyint(1)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserFlags", x => new { x.FlagId, x.UserUUID });
+                    table.ForeignKey(
+                        name: "FK_UserFlags_Flags_FlagId",
+                        column: x => x.FlagId,
+                        principalTable: "Flags",
+                        principalColumn: "FlagId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserFlags_Users_UserUUID",
+                        column: x => x.UserUUID,
+                        principalTable: "Users",
+                        principalColumn: "UserUUID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserFlags_UserUUID",
+                table: "UserFlags",
+                column: "UserUUID");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserFlags");
+
+            migrationBuilder.DropTable(
+                name: "Flags");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsQueued",
+                table: "Users",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "NotificationsMuted",
+                table: "Users",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "UserIsAdmin",
+                table: "Users",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "UserIsStaff",
+                table: "Users",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/Models/User/User.cs
+++ b/Models/User/User.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using GaryPortalAPI.Models;
 using GaryPortalAPI.Models.Feed;
 using Newtonsoft.Json;
@@ -49,11 +50,7 @@ namespace GaryPortalAPI.Models
         public string UserQuote { get; set; }
         public string UserBio { get; set; }
         public string UserGender { get; set; }
-        public bool NotificationsMuted { get; set; }
-        public bool UserIsStaff { get; set; }
-        public bool UserIsAdmin { get; set; }
         public string UserStanding { get; set; }
-        public bool IsQueued { get; set; }
         public DateTime UserCreatedAt { get; set; }
         public DateTime UserDateOfBirth { get; set; }
         public bool IsDeleted { get; set; }
@@ -77,17 +74,41 @@ namespace GaryPortalAPI.Models
 
         public virtual ICollection<UserAPNS> APNSTokens { get; set; }
 
+        public virtual ICollection<UserFlag> UserFlags { get; set; }
+
         public virtual UserDTO ConvertToDTO()
         {
             return new UserDTO
             {
                 UserUUID = UserUUID,
                 UserFullName = UserFullName,
-                UserIsAdmin = UserIsAdmin,
-                UserIsStaff = UserIsStaff,
+                UserIsAdmin = HasUserFlag("Role.Admin"),
+                UserIsStaff = HasUserFlag("Role.Staff"),
                 UserProfileImageUrl = UserProfileImageUrl,
             };
         }
+
+        public bool HasUserFlag(string flagName)
+        {
+            return UserFlags.Any(uf => uf.Flag.FlagName.ToLower() == flagName.ToLower() && uf.FlagEnabled && !uf.Flag.FlagIsDeleted);
+        }
+    }
+
+    public class Flag
+    {
+        public int FlagId { get; set; }
+        public string FlagName { get; set; }
+        public int FlagAccessLevel { get; set; }
+        public bool FlagIsDeleted { get; set; }
+    }
+
+    public class UserFlag
+    {
+        public string UserUUID { get; set; }
+        public int FlagId { get; set; }
+        public bool FlagEnabled { get; set; }
+
+        public virtual Flag Flag { get; set; }
     }
 
     public class UserTeam
@@ -97,7 +118,6 @@ namespace GaryPortalAPI.Models
 
         public virtual Team Team { get; set; }
         public virtual User User { get; set; }
-
     }
 
     public class UserRanks

--- a/Models/User/User.cs
+++ b/Models/User/User.cs
@@ -55,6 +55,13 @@ namespace GaryPortalAPI.Models
         public DateTime UserDateOfBirth { get; set; }
         public bool IsDeleted { get; set; }
 
+        [Obsolete("Please use the UserFlag system instead (HasUserFlag())")]
+        public bool UserIsStaff => HasUserFlag("Role.Staff");
+        [Obsolete("Please use the UserFlag system instead (HasUserFlag())")]
+        public bool UserIsAdmin => HasUserFlag("Role.Admin");
+        [Obsolete("Please use the UserFlag system instead (HasUserFlag())")]
+        public bool IsQueued => HasUserFlag("IsInQueue");
+
         public UserAuthenticationTokens UserAuthTokens { get; set; }
 
         public virtual UserAuthentication UserAuthentication { get; set; }

--- a/Services/IAppService.cs
+++ b/Services/IAppService.cs
@@ -13,6 +13,7 @@ namespace GaryPortalAPI.Services
         Task<ICollection<Sticker>> GetStickersAsync();
         Task<ICollection<Event>> GetEventsAsync(int teamId, CancellationToken ct = default);
         Task<ICollection<Commandment>> GetCommandmentsAsync(CancellationToken ct = default);
+        Task<ICollection<Flag>> GetAllFlagsAsync(CancellationToken ct = default);
     }
 
     public class AppService : IAppService
@@ -51,6 +52,15 @@ namespace GaryPortalAPI.Services
                 .AsNoTracking()
                 .Where(c => !c.CommandmentIsDeleted)
                 .ToListAsync(ct);
+        }
+
+        public async Task<ICollection<Flag>> GetAllFlagsAsync(CancellationToken ct = default)
+        {
+            return await _context
+                .Flags
+                .AsNoTracking()
+                .Where(c => !c.FlagIsDeleted)
+                .ToListAsync();
         }
     }
 }

--- a/Services/IChatBotService.cs
+++ b/Services/IChatBotService.cs
@@ -131,7 +131,7 @@ namespace GaryPortalAPI.Services
         {
             User user = await _userService.GetByIdAsync(uuid);
             return $"{user.UserFullName}:\nTeam: {user.UserTeam.Team.TeamName}\nAmigo Rank: {user.UserRanks.AmigoRank.RankName}\nPositive Rank: {user.UserRanks.PositivityRank.RankName}" +
-                $"\nStaff: {(user.UserIsStaff ? "Yes": "No")}\nAdmin: {(user.UserIsAdmin ? "Yes" : "No")}";
+                $"\nStaff: {(user.HasUserFlag("Role.Staff") ? "Yes": "No")}\nAdmin: {(user.HasUserFlag("Role.Admin") ? "Yes" : "No")}";
         }
 
         private static string HandleMock(string input)
@@ -191,7 +191,7 @@ namespace GaryPortalAPI.Services
         private async Task<string> HandleGlobalBan(string input, string uuid)
         {
             User user = await _userService.GetByIdAsync(uuid);
-            if (!user.UserIsAdmin)
+            if (!user.HasUserFlag("Role.Admin"))
             {
                 return "Error: Only Admin+ Can use this command here, if you are a staff member, you can also use the Staff Room in the app to manager user's bans";
             }
@@ -218,7 +218,7 @@ namespace GaryPortalAPI.Services
         private async Task<string> HandleChatBan(string input, string uuid)
         {
             User user = await _userService.GetByIdAsync(uuid);
-            if (!user.UserIsAdmin)
+            if (!user.HasUserFlag("Role.Admin"))
             {
                 return "Error: Only Admin+ Can use this command here, if you are a staff member, you can also use the Staff Room in the app to manager user's bans";
             }
@@ -245,7 +245,7 @@ namespace GaryPortalAPI.Services
         private async Task<string> HandleFeedBan(string input, string uuid)
         {
             User user = await _userService.GetByIdAsync(uuid);
-            if (!user.UserIsAdmin)
+            if (!user.HasUserFlag("Role.Admin"))
             {
                 return "Error: Only Admin+ Can use this command here, if you are a staff member, you can also use the Staff Room in the app to manager user's bans";
             }

--- a/Services/IChatService.cs
+++ b/Services/IChatService.cs
@@ -292,7 +292,6 @@ namespace GaryPortalAPI.Services
             if (file == null) return null;
 
             string uuid = Guid.NewGuid().ToString();
-            Directory.CreateDirectory($"/var/www/cdn/GaryPortal/Chat/{chatUUID}/Attachments/");
             string newFileName = file.FileName.Replace(Path.GetFileNameWithoutExtension(file.FileName), uuid);
             await _cdnService.UploadChatAttachment(newFileName, file, chatUUID, ct);           
             return $"https://cdn.tomk.online/GaryPortal/Chat/{chatUUID}/Attachments/{newFileName}";

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -44,7 +44,7 @@ namespace GaryPortalAPI.Services
         Task AddAPNS(string uuid, string apns);
         Task<ICollection<string>> GetAPNSFromUUIDAsync(string uuid, CancellationToken ct = default);
         Task PostNotification(string apns, Notification notification);
-
+        Task<UserFlag> SetUserFlag(string userUUID, string flagName, bool enabled, CancellationToken ct = default);
 
     }
 
@@ -81,7 +81,9 @@ namespace GaryPortalAPI.Services
                     .ThenInclude(ut => ut.Team)
                 .Include(u => u.UserBans.Where(ub => ub.BanExpires > DateTime.UtcNow))
                     .ThenInclude(ub => ub.BanType)
-                .Where(u => !u.IsDeleted && (teamId == 0 || u.UserTeam.TeamId == teamId) && (includeQueue || !u.IsQueued))
+                .Include(u => u.UserFlags)
+                    .ThenInclude(uf => uf.Flag)
+                .Where(u => !u.IsDeleted && (teamId == 0 || u.UserTeam.TeamId == teamId) && (includeQueue || !u.HasUserFlag("IsInQueue")))
                 .ToListAsync(ct);
         }
 
@@ -99,7 +101,9 @@ namespace GaryPortalAPI.Services
                     .ThenInclude(ut => ut.Team)
                 .Include(u => u.UserBans.Where(ub => ub.BanExpires > DateTime.UtcNow))
                     .ThenInclude(ub => ub.BanType)
-                .Where(u => !u.IsDeleted && u.IsQueued)
+                .Include(u => u.UserFlags)
+                    .ThenInclude(uf => uf.Flag)
+                .Where(u => !u.IsDeleted && u.HasUserFlag("IsInQueue"))
                 .ToListAsync(ct);
         }
 
@@ -118,6 +122,8 @@ namespace GaryPortalAPI.Services
                 .Include(u => u.BlockedUsers.Where(bu => bu.IsBlocked))
                 .Include(u => u.UserBans.Where(ub => ub.BanExpires > DateTime.UtcNow))
                     .ThenInclude(ub => ub.BanType)
+                .Include(u => u.UserFlags)
+                    .ThenInclude(uf => uf.Flag)
                 .FirstOrDefaultAsync(u => u.UserUUID == userUUID, ct);
         }
 
@@ -199,11 +205,14 @@ namespace GaryPortalAPI.Services
             user.UserName = details.UserName.ToLower();
             user.UserFullName = details.FullName;
             user.UserProfileImageUrl = details.ProfilePictureUrl;
-            user.NotificationsMuted = details.NotificationsMuted;
+            if (user.HasUserFlag("NotificationsMuted") != details.NotificationsMuted)
+            {
+                await SetUserFlag(uuid, "NotificationsMuted", details.NotificationsMuted);
+            }
             _context.Update(user);
 
             await _context.SaveChangesAsync(ct);
-            return user;
+            return await GetByIdAsync(uuid, ct);
         }
 
         public async Task<User> StaffManageUserDetailsAsync(string uuid, StaffManagedUserDetails details, CancellationToken ct = default)
@@ -215,9 +224,9 @@ namespace GaryPortalAPI.Services
             user.UserPoints.AmigoPoints = details.AmigoPoints;
             user.UserPoints.PositivityPoints = details.PositivePoints;
 
-            if (user.IsQueued != details.IsQueued)
+            if (user.HasUserFlag("IsInQueue") != details.IsQueued)
             {
-                user.IsQueued = details.IsQueued;
+                await SetUserFlag(uuid, "IsInQueue", details.IsQueued, ct);
                 if (details.IsQueued == false)
                 {
                     ICollection<string> apns = await GetAPNSFromUUIDAsync(user.UserUUID);
@@ -286,12 +295,8 @@ namespace GaryPortalAPI.Services
                     UserSpanishName = "",
                     UserStanding = "",
                     UserProfileImageUrl = "",
-                    UserIsAdmin = false,
-                    UserIsStaff = false,
-                    IsQueued = true,
                     UserGender = creatingUser.UserGender,
                     UserDateOfBirth = creatingUser.UserDOB,
-                    NotificationsMuted = false,
                     UserAuthentication = new UserAuthentication
                     {
                         UserEmail = creatingUser.UserEmail,
@@ -316,6 +321,7 @@ namespace GaryPortalAPI.Services
                 await _context.Users.AddAsync(newUser);
                 await _context.SaveChangesAsync();
                 User user = await GetByIdAsync(newUser.UserUUID, ct);
+                user.UserFlags.Add(await SetUserFlag(user.UserUUID, "IsInQueue", true, ct));
                 return user;
             }
 
@@ -439,7 +445,13 @@ namespace GaryPortalAPI.Services
 
         public async Task<ICollection<string>> GetAPNSFromUUIDAsync(string uuid, CancellationToken ct = default)
         {
-            if (await _context.Users.Where(u => u.UserUUID == uuid).Select(u => u.NotificationsMuted == false).FirstOrDefaultAsync(ct))
+            if (await _context.Users
+                .Include(u => u.UserFlags)
+                    .ThenInclude(uf => uf.Flag)
+                .Where(u => u.UserUUID == uuid)
+                .Select(u => u.HasUserFlag("NotificationsMuted") == false)
+                .FirstOrDefaultAsync(ct)
+            )
             {
                 return await _context.UserAPNS.Where(u => u.UserUUID == uuid).Select(u => u.APNSToken).ToListAsync(ct);
             }
@@ -451,6 +463,37 @@ namespace GaryPortalAPI.Services
             ApnSettings apnSettings = _apiSettings.APNSSettings.ConvertToAPNSettings();
             var apn = new ApnSender(apnSettings, new System.Net.Http.HttpClient());
             await apn.SendAsync(notification, apns);
+        }
+
+        public async Task<UserFlag> SetUserFlag(string userUUID, string flagName, bool enabled, CancellationToken ct = default)
+        {
+            User user = await _context.Users.FindAsync(userUUID);
+            Flag flag = await _context.Flags.FirstOrDefaultAsync(f => f.FlagName.ToLower() == flagName.ToLower());
+            if (user == null || flag == null)
+            {
+                return null;
+            }
+
+            bool flagExists = _context.UserFlags.Any(uf => uf.UserUUID == userUUID && uf.FlagId == flag.FlagId);
+            UserFlag userFlag = new UserFlag
+            {
+                Flag = flag,
+                FlagId = flag.FlagId,
+                FlagEnabled = enabled,
+                UserUUID = userUUID
+            };
+
+            if (flagExists)
+            {
+                _context.Update(userFlag);
+            }
+            else
+            {
+                _context.Add(userFlag);
+            }
+
+            await _context.SaveChangesAsync();
+            return userFlag;
         }
     }
 }

--- a/Startup.cs
+++ b/Startup.cs
@@ -36,6 +36,16 @@ namespace GaryPortalAPI
                     option.SerializerSettings.DateFormatString = "yyyy-MM-dd HH:mm:ss";
                 });
 
+            services.AddCors(options =>
+            {
+                options.AddPolicy("CorsPolicy", builder =>
+                {
+                    builder.WithOrigins("https://localhost:3000", "localhost:3000", "http://localhost:3000");
+                    builder.AllowCredentials();
+                    builder.AllowAnyHeader();
+                });
+            });
+
             services.AddRazorPages().AddRazorRuntimeCompilation();
             services.AddSwaggerGen();
 
@@ -102,6 +112,8 @@ namespace GaryPortalAPI
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();
+
+            app.UseCors("CorsPolicy");
 
             app.UseRouting();
 


### PR DESCRIPTION
# Description

This PR would introduce a 'flag' system to the API. The basic 'Flag' class simply looks like:
```
FlagId (PK), FlagName, FlagAccessLevel, FlagIsDeleted
```

Flags exist in isolation and are not tied to any one entity by themselves, however this PR introduces the 'UserFlag' entity:
```
UserUUID, FlagId, FlagEnabled
```

This allows flags to be tied to users. This system **REPLACES** how admins and staff members are handled. The old system relied on a bit field on the User entity (UserIsStaff, UserIsAdmin). Now, users would have a flag indicating their admin or staff status. Additionally, this allows for further user flags to be added with ease, i.e. a flag to restrict the silliness shown to them in-app. 

For reference, the current flags in the database are:
```
- Role.Staff
- Role.Admin
- NotificationsMuted
- IsInQueue
- RestrictSilliness
```

This PR **removes** the `NotifcationsMuted` field from the `User` entity, the `UserIsStaff`, `UserIsAdmin` and `IsQueued` properties remain, but are **obsoleted** and are no longer stored in the database. A new method `HasUserFlag(flagName) -> bool` has been added to the `User` entity, returning true if the flag is found and enabled. The obsoleted user properties pull from this method, so can continue to be used and referenced by old API clients. All API methods which get the full user have been updated to include UserFlags. 

Additionally, there is a new endpoint to `Users/SetUserFlag`, allowing a user flag to be toggled for a user, and an `App/Flags` endpoint to retrieve all Flags (not user flags, the Flags themselves).

------

This change allows for a much more versatile and modular way of flagging users, or any entity, for any reason whatsoever. 

-----

**THIS UPDATE HAS A BREAKING CHANGE, `NotificationsMuted` NO LONGER EXISTS ON THE USER ENTITY.**
**THE `UserIsStaff`, `UserIsAdmin` AND `IsQueued` PROPERTIES ON THE USER ENTITY ARE DEPRECATED** 