### PR TITLE
Hotfix: AutoInclude Flag data

### DIFF
--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -132,6 +132,8 @@ public class AppDbContext : DbContext
                 .OnDelete(DeleteBehavior.Cascade)
                 .IsRequired();
 
+            entity.Navigation(u => u.UserFlags).AutoInclude();
+
             entity.Ignore(u => u.UserIsStaff);
             entity.Ignore(u => u.UserIsAdmin);
             entity.Ignore(u => u.IsQueued);
@@ -233,6 +235,8 @@ public class AppDbContext : DbContext
                 .HasForeignKey(uf => uf.FlagId)
                 .OnDelete(DeleteBehavior.Cascade)
                 .IsRequired();
+
+            entity.Navigation(uf => uf.Flag).AutoInclude();
         });
 
         #endregion User

--- a/Services/Authentication/ITokenService.cs
+++ b/Services/Authentication/ITokenService.cs
@@ -44,7 +44,7 @@ namespace GaryPortalAPI.Services.Authentication
 
         public async Task<string> CreateAuthTokenForUserAsync(string userUUID)
         {
-            User user = await _context.Users.Include(u => u.UserFlags).ThenInclude(uf => uf.Flag).FirstOrDefaultAsync(u => u.UserUUID == userUUID);
+            User user = await _context.Users.FirstOrDefaultAsync(u => u.UserUUID == userUUID);
             if (user == null)
                 return null;
 

--- a/Services/IAppService.cs
+++ b/Services/IAppService.cs
@@ -60,7 +60,7 @@ namespace GaryPortalAPI.Services
                 .Flags
                 .AsNoTracking()
                 .Where(c => !c.FlagIsDeleted)
-                .ToListAsync();
+                .ToListAsync(cancellationToken: ct);
         }
     }
 }

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -81,8 +81,6 @@ namespace GaryPortalAPI.Services
                     .ThenInclude(ut => ut.Team)
                 .Include(u => u.UserBans.Where(ub => ub.BanExpires > DateTime.UtcNow))
                     .ThenInclude(ub => ub.BanType)
-                .Include(u => u.UserFlags)
-                    .ThenInclude(uf => uf.Flag)
                 .Where(u => !u.IsDeleted && (teamId == 0 || u.UserTeam.TeamId == teamId) && (includeQueue || !u.HasUserFlag("IsInQueue")))
                 .ToListAsync(ct);
         }
@@ -101,8 +99,6 @@ namespace GaryPortalAPI.Services
                     .ThenInclude(ut => ut.Team)
                 .Include(u => u.UserBans.Where(ub => ub.BanExpires > DateTime.UtcNow))
                     .ThenInclude(ub => ub.BanType)
-                .Include(u => u.UserFlags)
-                    .ThenInclude(uf => uf.Flag)
                 .Where(u => !u.IsDeleted && u.HasUserFlag("IsInQueue"))
                 .ToListAsync(ct);
         }
@@ -122,8 +118,6 @@ namespace GaryPortalAPI.Services
                 .Include(u => u.BlockedUsers.Where(bu => bu.IsBlocked))
                 .Include(u => u.UserBans.Where(ub => ub.BanExpires > DateTime.UtcNow))
                     .ThenInclude(ub => ub.BanType)
-                .Include(u => u.UserFlags)
-                    .ThenInclude(uf => uf.Flag)
                 .FirstOrDefaultAsync(u => u.UserUUID == userUUID, ct);
         }
 
@@ -446,8 +440,6 @@ namespace GaryPortalAPI.Services
         public async Task<ICollection<string>> GetAPNSFromUUIDAsync(string uuid, CancellationToken ct = default)
         {
             if (await _context.Users
-                .Include(u => u.UserFlags)
-                    .ThenInclude(uf => uf.Flag)
                 .Where(u => u.UserUUID == uuid)
                 .Select(u => u.HasUserFlag("NotificationsMuted") == false)
                 .FirstOrDefaultAsync(ct)


### PR DESCRIPTION
# Description:

**Issue:** Although flag data was included on User queries, it was not included on any other queries (i.e. getting last chat message), and so HasUserFlag() failed where the `UserFlags` collection was null rather than empty.

**Fix:** Using a relatively new-ish EF Core feature, UserFlags are now set to automatically be included in any user query, and the Flag is automatically included in any UserFlag query. This resolves the issue as we no longer need to consider placing 
```
.Include(entity => entity.User)
    .ThenInclude(user => user.UserFlags)
        .ThenInclude(userFlag => userFlag.Flag);
```
on a query, instead we can just do:
```
.Include(entity => entity.User);
```
which is already in place.

**Notes:**
- Although it is not used anywhere in the API as it is not yet necessary, the auto-include feature for flags can be disabled with the `.IgnoreAutoIncludes()` method on any query builder. 
- See [Auto include documenation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.metadata.builders.navigationbuilder.autoinclude?view=efcore-5.0) and [IgnoreAutoIncludes documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.query.querycompilationcontext.ignoreautoincludes?view=efcore-5.0#Microsoft_EntityFrameworkCore_Query_QueryCompilationContext_IgnoreAutoIncludes)
- Also see a third-party guide for all the features with examples [here](https://dotnetcoretutorials.com/2021/03/07/eager-load-navigation-properties-by-default-in-ef-core/)